### PR TITLE
Use canonical ofx repository pending release of new gem version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ gem 'pg'
 gem 'haml'
 gem 'thin'
 
-# Avoid iconv deprecation warning
-gem 'ofx', :git => 'git://github.com/floehopper/ofx.git'
+# Avoid iconv deprecation warning pending release of new gem version
+gem 'ofx', :git => 'git://github.com/annacruz/ofx.git'
 
 gem 'exception_notification', :require => 'exception_notifier'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: git://github.com/floehopper/ofx.git
-  revision: d45a9f5d6567f2ebff34a78a24d0be83bb59ab33
+  remote: git://github.com/annacruz/ofx.git
+  revision: e9d2a94bf988f47e77e3f4803d27867375d72450
   specs:
-    ofx (0.3.1)
+    ofx (0.3.2)
       nokogiri
 
 GEM


### PR DESCRIPTION
Since my pull request [1] of 2 years ago has finally been merged, I thought it
would be better to depend on the canonical repo rather than my fork.

[1] https://github.com/annacruz/ofx/pull/7
