### PR TITLE
Display account name against transaction on edit pages.

### DIFF
--- a/app/views/transactions/bulk_edit.html.haml
+++ b/app/views/transactions/bulk_edit.html.haml
@@ -24,6 +24,7 @@
   %thead
     %tr
       %th Date
+      %th Account
       %th Description
       %th Location
       %th Paid in
@@ -40,6 +41,8 @@
               Original:
               %span.text-info.original_date= transaction.original_date
             = transaction_form.submit 'Save date', id: nil
+        %td
+          %span.text-info.account_name= transaction.account.name
         %td
           = form_for(transaction, html: {id: nil}) do |transaction_form|
             = transaction_form.text_field :description, size: '80', id: nil, value: transaction.description, class: 'description'

--- a/app/views/transactions/edit.html.haml
+++ b/app/views/transactions/edit.html.haml
@@ -7,6 +7,10 @@
 
 = form_for @transaction do |transaction_form|
   %div
+    %span.help-block
+      Account:
+      %span.text-info.account_name= @transaction.account.name
+  %div
     = transaction_form.label :date
     = transaction_form.text_field :date, size: '10', value: @transaction.date
     %span.help-block

--- a/test/functional/transactions_controller_test.rb
+++ b/test/functional/transactions_controller_test.rb
@@ -66,6 +66,15 @@ class TransactionsControllerBulkEditTest < ActionController::TestCase
     assert_select "input[name='transaction[category]']"
   end
 
+  test 'displays the account name in the edit form' do
+    account = FactoryGirl.create(:account, name: 'account-name')
+    transaction = FactoryGirl.create(:transaction, account_id: account.id)
+
+    get :index, period: Date.today.to_s(:period), edit: true
+
+    assert_select '.account_name', 'account-name'
+  end
+
   test 'should display original values in the edit form' do
     date   = Date.parse('2011-01-01')
     period = date.to_s(:period)
@@ -216,6 +225,15 @@ class TransactionsControllerEditTest < ActionController::TestCase
     assert_select "input[name='transaction[location]']"
     assert_select "textarea[name='transaction[note]']"
     assert_select "input[name='transaction[category]']"
+  end
+
+  test 'displays the account name in the edit form' do
+    account = FactoryGirl.create(:account, name: 'account-name')
+    transaction = FactoryGirl.create(:transaction, account_id: account.id)
+
+    get :edit, id: transaction
+
+    assert_select '.account_name', 'account-name'
   end
 
   test 'displays the original date in the edit form' do


### PR DESCRIPTION
I found it useful to have this information available when annotating my transactions.

I'm not 100% sure about the layout/styling, but I think it's ok.
