### PR TITLE
Fix ofx dependency problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 
 # Avoid iconv deprecation warning
-gem 'ofx', git: 'git://github.com/annacruz/ofx.git'
+gem 'ofx', git: 'https://github.com/annacruz/ofx.git'
 
 # Send exception notifications by email
 gem 'exception_notification'

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 
 # Avoid iconv deprecation warning
-gem 'ofx', git: 'git://github.com/chrisroos/ofx.git', branch: 'add-support-for-version-202-ofx-files'
+gem 'ofx', git: 'git://github.com/annacruz/ofx.git'
 
 # Send exception notifications by email
 gem 'exception_notification'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/annacruz/ofx.git
+  remote: https://github.com/annacruz/ofx.git
   revision: 70e99076440bd2915b10d59298c1d063b0ef6f57
   specs:
     ofx (0.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: git://github.com/chrisroos/ofx.git
-  revision: 1b04543227d10da2d2100695071c142cc7f82184
-  branch: add-support-for-version-202-ofx-files
+  remote: git://github.com/annacruz/ofx.git
+  revision: 70e99076440bd2915b10d59298c1d063b0ef6f57
   specs:
     ofx (0.3.2)
       nokogiri


### PR DESCRIPTION
* Fix error on `bundle install` caused by removal of branch on merge of annacruz/ofx#14.
* Fix warning on `bundle install` caused by use of `git` vs `https` protocol in `Gemfile`.